### PR TITLE
fix(server-dry-run): rework dry-run resource lists preparations

### DIFF
--- a/pkg/kube/resource.go
+++ b/pkg/kube/resource.go
@@ -17,10 +17,6 @@ limitations under the License.
 package kube // import "helm.sh/helm/v3/pkg/kube"
 
 import (
-	"bytes"
-	"encoding/json"
-	"fmt"
-
 	"k8s.io/cli-runtime/pkg/resource"
 )
 
@@ -88,19 +84,4 @@ func (r ResourceList) Intersect(rs ResourceList) ResourceList {
 // isMatchingInfo returns true if infos match on Name and GroupVersionKind.
 func isMatchingInfo(a, b *resource.Info) bool {
 	return a.Name == b.Name && a.Namespace == b.Namespace && a.Mapping.GroupVersionKind.Kind == b.Mapping.GroupVersionKind.Kind
-}
-
-func CopyResourceList(client Interface, r ResourceList) (ResourceList, error) {
-	var manifests string
-
-	for _, info := range r {
-		m, err := json.Marshal(info.Object)
-		if err != nil {
-			return nil, fmt.Errorf("unable to serialize resource %s/%s: %w", info.Mapping.GroupVersionKind.Kind, info.Name, err)
-		}
-
-		manifests += fmt.Sprintf("---\n%s\n", m)
-	}
-
-	return client.Build(bytes.NewBufferString(manifests), false)
 }


### PR DESCRIPTION
Do not use copy with marshal-unmarshal mechanics, instead prepare separate resource lists twice: for dry-run operation and regular operation.

Signed-off-by: Timofey Kirillov <timofey.kirillov@flant.com>
