### PR TITLE
[port from v3.8.0 branch] fix(server-dry-run): rework dry-run resource lists preparations

### DIFF
--- a/pkg/action/install.go
+++ b/pkg/action/install.go
@@ -302,16 +302,25 @@ func (i *Install) RunWithContext(ctx context.Context, chrt *chart.Chart, vals ma
 		return rel, nil
 	}
 
-	validateToBeAdopted, err := kube.CopyResourceList(i.cfg.KubeClient, toBeAdopted)
-	if err != nil {
-		return nil, fmt.Errorf("unable to prepare validation: %w", err)
-	}
-	validateResources, err := kube.CopyResourceList(i.cfg.KubeClient, resources)
-	if err != nil {
-		return nil, fmt.Errorf("unable to prepare validation resources: %w", err)
-	}
-	if err := i.validateInstallRelease(ctx, rel, validateToBeAdopted, validateResources); err != nil {
-		return nil, fmt.Errorf("install release validation failed: %w", err)
+	if isServerDryRunEnabled() {
+		var validateToBeAdopted kube.ResourceList
+		validateResources, err := i.cfg.KubeClient.Build(bytes.NewBufferString(rel.Manifest), !i.DisableOpenAPIValidation)
+		if err != nil {
+			return nil, errors.Wrap(err, "unable to build kubernetes objects from release manifest")
+		}
+		err = validateResources.Visit(setMetadataVisitor(rel.Name, rel.Namespace, true))
+		if err != nil {
+			return nil, err
+		}
+		if !i.ClientOnly && !isUpgrade && len(validateResources) > 0 {
+			validateToBeAdopted, err = existingResourceConflict(validateResources, rel.Name, rel.Namespace)
+			if err != nil {
+				return nil, errors.Wrap(err, "rendered manifests contain a resource that already exists. Unable to continue with install")
+			}
+		}
+		if err := i.validateInstallRelease(ctx, rel, validateToBeAdopted, validateResources); err != nil {
+			return nil, fmt.Errorf("install release validation failed: %w", err)
+		}
 	}
 
 	if i.CreateNamespace {
@@ -366,9 +375,7 @@ func (i *Install) RunWithContext(ctx context.Context, chrt *chart.Chart, vals ma
 }
 
 func (i *Install) validateInstallRelease(ctx context.Context, rel *release.Release, toBeAdopted kube.ResourceList, resources kube.ResourceList) error {
-	if !isServerDryRunEnabled() {
-		return nil
-	}
+	i.cfg.Log("starting server dry-run validation\n")
 
 	kubeClient, ok := i.cfg.KubeClient.(kube.InterfaceExt)
 	if !ok {
@@ -402,6 +409,9 @@ func (i *Install) validateInstallRelease(ctx context.Context, rel *release.Relea
 	if result.e != nil {
 		return fmt.Errorf("server dry run release install failed: %w", result.e)
 	}
+
+	i.cfg.Log("server dry-run validation succeeded\n")
+
 	return nil
 }
 

--- a/pkg/action/upgrade.go
+++ b/pkg/action/upgrade.go
@@ -256,27 +256,27 @@ func (u *Upgrade) prepareUpgrade(name string, chart *chart.Chart, vals map[strin
 	return currentRelease, upgradedRelease, err
 }
 
-func (u *Upgrade) performUpgrade(ctx context.Context, originalRelease, upgradedRelease *release.Release) (*release.Release, error) {
+func (u *Upgrade) prepareUpgradeResourcesLists(ctx context.Context, originalRelease, upgradedRelease *release.Release) (kube.ResourceList, kube.ResourceList, *release.Release, error) {
 	current, err := u.cfg.KubeClient.Build(bytes.NewBufferString(originalRelease.Manifest), false)
 	if err != nil {
 		// Checking for removed Kubernetes API error so can provide a more informative error message to the user
 		// Ref: https://github.com/helm/helm/issues/7219
 		if strings.Contains(err.Error(), "unable to recognize \"\": no matches for kind") {
-			return upgradedRelease, errors.Wrap(err, "current release manifest contains removed kubernetes api(s) for this "+
+			return nil, nil, upgradedRelease, errors.Wrap(err, "current release manifest contains removed kubernetes api(s) for this "+
 				"kubernetes version and it is therefore unable to build the kubernetes "+
 				"objects for performing the diff. error from kubernetes")
 		}
-		return upgradedRelease, errors.Wrap(err, "unable to build kubernetes objects from current release manifest")
+		return nil, nil, upgradedRelease, errors.Wrap(err, "unable to build kubernetes objects from current release manifest")
 	}
 	target, err := u.cfg.KubeClient.Build(bytes.NewBufferString(upgradedRelease.Manifest), !u.DisableOpenAPIValidation)
 	if err != nil {
-		return upgradedRelease, errors.Wrap(err, "unable to build kubernetes objects from new release manifest")
+		return nil, nil, upgradedRelease, errors.Wrap(err, "unable to build kubernetes objects from new release manifest")
 	}
 
 	// It is safe to use force only on target because these are resources currently rendered by the chart.
 	err = target.Visit(setMetadataVisitor(upgradedRelease.Name, upgradedRelease.Namespace, true))
 	if err != nil {
-		return upgradedRelease, err
+		return nil, nil, upgradedRelease, err
 	}
 
 	// Do a basic diff using gvk + name to figure out what new resources are being created so we can validate they don't already exist
@@ -294,7 +294,7 @@ func (u *Upgrade) performUpgrade(ctx context.Context, originalRelease, upgradedR
 
 	toBeUpdated, err := existingResourceConflict(toBeCreated, upgradedRelease.Name, upgradedRelease.Namespace)
 	if err != nil {
-		return nil, errors.Wrap(err, "rendered manifests contain a resource that already exists. Unable to continue with update")
+		return nil, nil, nil, errors.Wrap(err, "rendered manifests contain a resource that already exists. Unable to continue with update")
 	}
 
 	toBeUpdated.Visit(func(r *resource.Info, err error) error {
@@ -304,6 +304,15 @@ func (u *Upgrade) performUpgrade(ctx context.Context, originalRelease, upgradedR
 		current.Append(r)
 		return nil
 	})
+
+	return current, target, upgradedRelease, nil
+}
+
+func (u *Upgrade) performUpgrade(ctx context.Context, originalRelease, upgradedRelease *release.Release) (*release.Release, error) {
+	current, target, errUpgradedRelease, err := u.prepareUpgradeResourcesLists(ctx, originalRelease, upgradedRelease)
+	if err != nil {
+		return errUpgradedRelease, err
+	}
 
 	if u.DryRun {
 		u.cfg.Log("dry run for %s", upgradedRelease.Name)
@@ -315,16 +324,14 @@ func (u *Upgrade) performUpgrade(ctx context.Context, originalRelease, upgradedR
 		return upgradedRelease, nil
 	}
 
-	validateCurrent, err := kube.CopyResourceList(u.cfg.KubeClient, current)
-	if err != nil {
-		return nil, fmt.Errorf("unable to prepare validation current resources: %w", err)
-	}
-	validateTarget, err := kube.CopyResourceList(u.cfg.KubeClient, target)
-	if err != nil {
-		return nil, fmt.Errorf("unable to prepare validation current resources: %w", err)
-	}
-	if err := u.validateUpgradeRelease(ctx, upgradedRelease, validateCurrent, validateTarget); err != nil {
-		return upgradedRelease, fmt.Errorf("upgrade release validation failed: %w", err)
+	if isServerDryRunEnabled() {
+		validateCurrent, validateTarget, errUpgradedRelease, err := u.prepareUpgradeResourcesLists(ctx, originalRelease, upgradedRelease)
+		if err != nil {
+			return errUpgradedRelease, err
+		}
+		if err := u.validateUpgradeRelease(ctx, upgradedRelease, validateCurrent, validateTarget); err != nil {
+			return upgradedRelease, fmt.Errorf("upgrade release validation failed: %w", err)
+		}
 	}
 
 	u.cfg.Log("creating upgraded release for %s", upgradedRelease.Name)
@@ -371,9 +378,7 @@ func (u *Upgrade) handleContext(ctx context.Context, done chan interface{}, c ch
 }
 
 func (u *Upgrade) validateUpgradeRelease(ctx context.Context, upgradedRelease *release.Release, current, target kube.ResourceList) error {
-	if !isServerDryRunEnabled() {
-		return nil
-	}
+	u.cfg.Log("starting server dry-run validation\n")
 
 	kubeClient, ok := u.cfg.KubeClient.(kube.InterfaceExt)
 	if !ok {
@@ -409,6 +414,8 @@ func (u *Upgrade) validateUpgradeRelease(ctx context.Context, upgradedRelease *r
 	if resErr != nil {
 		return fmt.Errorf("server dry run release upgrade failed: %w", resErr)
 	}
+
+	u.cfg.Log("server dry-run validation succeeded\n")
 
 	return nil
 }

--- a/pkg/kube/resource.go
+++ b/pkg/kube/resource.go
@@ -17,10 +17,6 @@ limitations under the License.
 package kube // import "helm.sh/helm/v3/pkg/kube"
 
 import (
-	"bytes"
-	"encoding/json"
-	"fmt"
-
 	"k8s.io/cli-runtime/pkg/resource"
 )
 
@@ -88,19 +84,4 @@ func (r ResourceList) Intersect(rs ResourceList) ResourceList {
 // isMatchingInfo returns true if infos match on Name and GroupVersionKind.
 func isMatchingInfo(a, b *resource.Info) bool {
 	return a.Name == b.Name && a.Namespace == b.Namespace && a.Mapping.GroupVersionKind.Kind == b.Mapping.GroupVersionKind.Kind
-}
-
-func CopyResourceList(client Interface, r ResourceList) (ResourceList, error) {
-	var manifests string
-
-	for _, info := range r {
-		m, err := json.Marshal(info.Object)
-		if err != nil {
-			return nil, fmt.Errorf("unable to serialize resource %s/%s: %w", info.Mapping.GroupVersionKind.Kind, info.Name, err)
-		}
-
-		manifests += fmt.Sprintf("---\n%s\n", m)
-	}
-
-	return client.Build(bytes.NewBufferString(manifests), false)
 }


### PR DESCRIPTION
Do not use copy with marshal-unmarshal mechanics, instead prepare separate resource lists twice: for dry-run operation and regular operation.

Signed-off-by: Timofey Kirillov <timofey.kirillov@flant.com>