### PR TITLE
fix(helm for werf): solved broken 3 way merge case when pre-upgrade hook fails

### DIFF
--- a/pkg/action/upgrade.go
+++ b/pkg/action/upgrade.go
@@ -362,6 +362,8 @@ func (u *Upgrade) releasingUpgrade(c chan<- resultMessage, upgradedRelease *rele
 
 	if !u.DisableHooks {
 		if err := u.cfg.execHook(upgradedRelease, release.HookPreUpgrade, u.Timeout); err != nil {
+			// write original manifests into upgradedRelease because actually no changes has been introduced into the cluster
+			upgradedRelease.Manifest = originalRelease.Manifest
 			u.reportToPerformUpgrade(c, upgradedRelease, kube.ResourceList{}, fmt.Errorf("pre-upgrade hooks failed: %s", err))
 			return
 		}


### PR DESCRIPTION
Helm does not remove env-variable if pre-upgrade hook failed in the first deploy and succeeded next time.

More info about the case: https://github.com/werf/werf/issues/4155

Signed-off-by: Timofey Kirillov <timofey.kirillov@flant.com>
