### PR TITLE
fix: cleanupOnFail imrovements

### DIFF
--- a/cmd/helm/install.go
+++ b/cmd/helm/install.go
@@ -124,6 +124,7 @@ type InstallCmdOptions struct {
 	Wait              *bool
 	Atomic            *bool
 	Timeout           *time.Duration
+	CleanupOnFail     *bool
 
 	StagesExternalDepsGenerator phases.ExternalDepsGenerator
 }
@@ -163,6 +164,9 @@ func NewInstallCmd(cfg *action.Configuration, out io.Writer, opts InstallCmdOpti
 			if opts.Timeout != nil {
 				client.Timeout = *opts.Timeout
 			}
+			if opts.CleanupOnFail != nil {
+				client.CleanupOnFail = *opts.CleanupOnFail
+			}
 
 			rel, err := runInstall(args, client, valueOpts, out)
 			if err != nil {
@@ -197,6 +201,7 @@ func addInstallFlags(cmd *cobra.Command, f *pflag.FlagSet, client *action.Instal
 	f.BoolVar(&client.Atomic, "atomic", false, "if set, the installation process deletes the installation on failure. The --wait flag will be set automatically if --atomic is used")
 	f.BoolVar(&client.SkipCRDs, "skip-crds", false, "if set, no CRDs will be installed. By default, CRDs are installed if not already present")
 	f.BoolVar(&client.SubNotes, "render-subchart-notes", false, "if set, render subchart notes along with the parent")
+	f.BoolVar(&client.CleanupOnFail, "cleanup-on-fail", false, "allow deletion of new resources created in this installation when install fails")
 	addValueOptionsFlags(f, valueOpts)
 	addChartPathOptionsFlags(f, &client.ChartPathOptions)
 

--- a/cmd/helm/rollback.go
+++ b/cmd/helm/rollback.go
@@ -41,6 +41,7 @@ To see revision numbers, run 'helm history RELEASE'.
 
 type RollbackCmdOptions struct {
 	StagesSplitter phases.Splitter
+	CleanupOnFail  *bool
 
 	StagesExternalDepsGenerator phases.ExternalDepsGenerator
 }
@@ -70,6 +71,10 @@ func NewRollbackCmd(cfg *action.Configuration, out io.Writer, opts RollbackCmdOp
 			return nil, cobra.ShellCompDirectiveNoFileComp
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if opts.CleanupOnFail != nil {
+				client.CleanupOnFail = *opts.CleanupOnFail
+			}
+
 			if len(args) > 1 {
 				ver, err := strconv.Atoi(args[1])
 				if err != nil {

--- a/cmd/helm/upgrade.go
+++ b/cmd/helm/upgrade.go
@@ -83,6 +83,7 @@ type UpgradeCmdOptions struct {
 	Atomic            *bool
 	Timeout           *time.Duration
 	IgnorePending     *bool
+	CleanupOnFail     *bool
 
 	StagesExternalDepsGenerator phases.ExternalDepsGenerator
 }
@@ -140,6 +141,9 @@ func NewUpgradeCmd(cfg *action.Configuration, out io.Writer, opts UpgradeCmdOpti
 			if opts.Timeout != nil {
 				client.Timeout = *opts.Timeout
 			}
+			if opts.CleanupOnFail != nil {
+				client.CleanupOnFail = *opts.CleanupOnFail
+			}
 
 			client.Namespace = settings.Namespace()
 
@@ -170,6 +174,7 @@ func NewUpgradeCmd(cfg *action.Configuration, out io.Writer, opts UpgradeCmdOpti
 					instClient.DisableOpenAPIValidation = client.DisableOpenAPIValidation
 					instClient.SubNotes = client.SubNotes
 					instClient.Description = client.Description
+					instClient.CleanupOnFail = client.CleanupOnFail
 
 					rel, err := runInstall(args, instClient, valueOpts, out)
 					if err != nil {

--- a/pkg/phases/phasemanagers/rollout_phase_manager.go
+++ b/pkg/phases/phasemanagers/rollout_phase_manager.go
@@ -59,7 +59,7 @@ func (m *RolloutPhaseManager) DoStage(
 		}
 
 		if err := applyFn(i, stg, m.previouslyDeployedResources.Intersect(stg.DesiredResources)); err != nil {
-			return fmt.Errorf("error applying resources: %w", err)
+			return &ApplyError{Err: err}
 		}
 
 		rel.SetRolloutPhaseStageInfo(m.Release, i)
@@ -97,4 +97,16 @@ func joinErrors(errs []error) string {
 	}
 
 	return strings.Join(es, "; ")
+}
+
+type ApplyError struct {
+	Err error
+}
+
+func (e ApplyError) Error() string {
+	return fmt.Sprintf("error applying resources: %s", e.Err.Error())
+}
+
+func (e ApplyError) Unwrap() error {
+	return e.Err
 }


### PR DESCRIPTION
Fixed:
* Half-succeeded deploys that created new resources won't break
  subsequent deploys.
* Created/Updated/Deleted internal Result resource lists were not
  consistent — now they represent what was actually done.
* CleanupOnFail now deletes only resources from the current stage
  instead of all stages.

Changed:
* CleanupOnFail now triggers only while applying manifests and
  won't be triggered while tracking resource progress (for easier
  debugging by user).

New:
* CleanupOnFail option for Install.