### PR TITLE
feat(helm for werf): rework uninstall-with-namespace procedure

### DIFF
--- a/cmd/helm/uninstall.go
+++ b/cmd/helm/uninstall.go
@@ -73,6 +73,8 @@ func NewUninstallCmd(cfg *action.Configuration, out io.Writer, opts UninstallCmd
 				client.DontFailIfNoRelease = *opts.DontFailIfNoRelease
 			}
 
+			client.Namespace = Settings.Namespace()
+
 			for i := 0; i < len(args); i++ {
 
 				res, err := client.Run(args[i])
@@ -83,7 +85,7 @@ func NewUninstallCmd(cfg *action.Configuration, out io.Writer, opts UninstallCmd
 					fmt.Fprintln(out, res.Info)
 				}
 
-				fmt.Fprintf(out, "release \"%s\" uninstalled\n", args[i])
+				fmt.Fprintf(out, "release \"%s\" successfully uninstalled\n", args[i])
 			}
 			return nil
 		},

--- a/pkg/kube/extensions.go
+++ b/pkg/kube/extensions.go
@@ -5,9 +5,13 @@ import (
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
-
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
+
+func IsNotFound(err error) bool {
+	return err != nil && apierrors.IsNotFound(err)
+}
 
 func (c *Client) DeleteNamespace(ctx context.Context, namespace string, opts DeleteOptions) error {
 	cs, err := c.Factory.KubernetesClientSet()


### PR DESCRIPTION
* improve logging: which namespace and release used, whether release and namespace actually exists;
* fix case when release already not-exists, but we need to remove namespace due to --with-namespace option.
