### PR TITLE
fix: don't rely on resource Group for resources equality matching

### DIFF
--- a/pkg/kube/resource.go
+++ b/pkg/kube/resource.go
@@ -113,16 +113,11 @@ func (r ResourceList) ToYamlDocs() (string, error) {
 	return manifestsStr, nil
 }
 
-// isMatchingInfo returns true if infos match on Name and GroupVersionKind.
+// isMatchingInfo returns true if infos match on Name/Namespace and Kind.
 func isMatchingInfo(a, b *resource.Info) bool {
-	return a.Name == b.Name && a.Namespace == b.Namespace && a.Mapping.GroupVersionKind.Kind == b.Mapping.GroupVersionKind.Kind && a.Mapping.GroupVersionKind.Group == b.Mapping.GroupVersionKind.Group
+	return a.Name == b.Name && a.Namespace == b.Namespace && a.Mapping.GroupVersionKind.Kind == b.Mapping.GroupVersionKind.Kind
 }
 
-func ResourceNameNamespaceGroupKind(info *resource.Info) string {
-	return fmt.Sprint(info.Namespace, ":", info.Object.GetObjectKind().GroupVersionKind().GroupKind().String(), "/", info.Name)
-}
-
-// Match by name, namespace, group, kind.
-func SameResources(info1, info2 *resource.Info) bool {
-	return ResourceNameNamespaceGroupKind(info1) == ResourceNameNamespaceGroupKind(info2)
+func ResourceNameNamespaceKind(info *resource.Info) string {
+	return fmt.Sprint(info.Namespace, ":", info.Object.GetObjectKind().GroupVersionKind().Kind, "/", info.Name)
 }

--- a/pkg/phases/rollout_phase.go
+++ b/pkg/phases/rollout_phase.go
@@ -126,8 +126,8 @@ func (m *RolloutPhase) validateStagesExternalDeps() error {
 	for _, stage := range m.SortedStages {
 		for _, stageExtDep := range stage.ExternalDependencies {
 			for _, phaseDesiredRes := range phaseDesiredResources {
-				if kube.SameResources(stageExtDep.Info, phaseDesiredRes) {
-					return fmt.Errorf("resources from current release can't be external dependencies: remove external dependency on %q", kube.ResourceNameNamespaceGroupKind(stageExtDep.Info))
+				if kube.ResourceNameNamespaceKind(stageExtDep.Info) == kube.ResourceNameNamespaceKind(phaseDesiredRes) {
+					return fmt.Errorf("resources from current release can't be external dependencies: remove external dependency on %q", kube.ResourceNameNamespaceKind(stageExtDep.Info))
 				}
 			}
 		}


### PR DESCRIPTION
Same underlying resource can be exposed on different API Groups and we have no sane way to determine on which API Groups it is exposed. Thus we ignore Group altogether, no better workaround for now.